### PR TITLE
Rename shift state setter for clarity

### DIFF
--- a/src/app/clock/page.tsx
+++ b/src/app/clock/page.tsx
@@ -28,7 +28,7 @@ export default function ClockPage() {
   const [selectedStore, setSelectedStore] = useState<string>("");
   const [role, setRole] = useState<Membership["role"] | null>(null);
   const [error, setError] = useState<string | null>(null);
-  const [shiftId, setshiftId] = useState<string | null>(null);
+  const [shiftId, setShiftId] = useState<string | null>(null);
   const router = useRouter();
 
   // Pull memberships on mount


### PR DESCRIPTION
## Summary
- rename setshiftId to setShiftId in clock page

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: React Hook "useState" cannot be called at the top level; Unexpected any types)*

------
https://chatgpt.com/codex/tasks/task_e_689a1e5b9748832d8223e398b1a2d194