### PR TITLE
Add reset redirect for password recovery

### DIFF
--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -10,6 +10,12 @@ import type { AuthChangeEvent, Session } from "@supabase/supabase-js";
 export default function LoginPage() {
   const router = useRouter();
   const [ready, setReady] = useState(false);
+  const [view, setView] = useState<ViewType>("sign_in");
+
+  const origin =
+    typeof window !== "undefined" ? window.location.origin : undefined;
+  const resetRedirect =
+    origin && view === "forgotten_password" ? `${origin}/auth/reset` : undefined;
 
   useEffect(() => {
     let mounted = true;
@@ -43,13 +49,10 @@ export default function LoginPage() {
         <Auth
           supabaseClient={supabase}
           providers={[]}
-          view={"sign_in" as ViewType}
+          view={view}
           appearance={{ theme: ThemeSupa }}
-          redirectTo={
-            typeof window !== "undefined"
-              ? `${window.location.origin}/clock`
-              : undefined
-          }
+          redirectTo={resetRedirect}
+          onViewChange={setView}
         />
       </div>
     </div>


### PR DESCRIPTION
## Summary
- compute page origin and redirect to a password reset page when in forgotten password view
- track auth view state so redirect only applies for password reset

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689bb5e98194832d9ff62be8c4a694e2