### PR TITLE
Ensure safe auth subscription cleanup in ClientHeader

### DIFF
--- a/src/app/clientheader.tsx
+++ b/src/app/clientheader.tsx
@@ -9,12 +9,17 @@ export default function ClientHeader() {
   const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   useEffect(() => {
-  supabase.auth.getUser().then(({ data }) => setIsLoggedIn(!!data.user));
-  const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
-    setIsLoggedIn(!!session?.user);
-  });
-  return () => sub.subscription.unsubscribe();
-}, []);
+    supabase.auth.getUser().then(({ data }) => setIsLoggedIn(!!data.user));
+    const { data: sub } = supabase.auth.onAuthStateChange((_e, session) => {
+      setIsLoggedIn(!!session?.user);
+    });
+
+    if (!sub || !sub.subscription) {
+      return;
+    }
+
+    return () => sub?.subscription?.unsubscribe();
+  }, []);
 
   async function handleLogout() {
     await supabase.auth.signOut();


### PR DESCRIPTION
## Summary
- verify auth subscription exists before cleanup in ClientHeader
- guard unsubscribe call with optional chaining

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689e296805bc832d8cec4037e0c8317d